### PR TITLE
Added TeoriaScale.name and TeoriaNote#atDistance

### DIFF
--- a/teoria.js
+++ b/teoria.js
@@ -359,6 +359,13 @@ var scope = (typeof exports === 'object') ? exports : window;
     },
 
     /**
+     * Returns the note at the specified semitone distance from this note.
+     */
+    atDistance: function(semitoneDistance) {
+      return teoria.note.fromKey(this.key() + semitoneDistance);
+    },
+
+    /**
      * Sugar function for teoria.scale(note, scale)
      */
     scale: function(scale) {


### PR DESCRIPTION
## TeoriaScale.name

I have encountered situations where I created a `TeoriaScale` object, and then later on wanted to refer to the name of the scale originally supplied to the constructor, but had no means of doing so. So I added a `name` field to the `TeoriaScale` class, which is automatically assigned a value in its constructor.

So if you supply a scale name string to `TeoriaScale`'s constructor, it will simply set the `name` field to that string. 

Example:

``` javascript
teoria.scale('c', 'mixolydian').name; //returns "mixolydian"
```

And if you supply an array of intervals as the scale to `TeoriaScale`'s constructor, it will lookup the name based on whether a matching array can be found in `teoria.scale.scales`. The lookup is O(N^2) because you are storing the scale arrays in an object literal. Whether that is acceptable or not is up to you, but since there aren't that many scales, I think it is. 

Example:

``` javascript
teoria.scale('c', ['M2', 'M3', 'P5', 'M6']).name //returns "majorpentatonic"
```

And obviously if you specify a scale array that doesn't match any of the arrays in `teoria.scale.scales`, the `name` field remains `undefined`, which is expected behaviour in my opinion. The alternative would be to make the constructor raise an error when it cannot find a matching scale array, but I figured maybe you still want to allow people to create custom scales that are not included in `teoria.scale.scales`, so I decided not to do that. If that isn't the case, then raising an error would be a nice way of preventing `TeoriaScale` objects from being constructed with no `name` field defined. 

Example:

``` javascript
teoria.scale('c', ['M2', 'm3', 'P4', 'm7']).name //returns undefined
```

However, it should be noted that if you specify an array that matches multiple scale arrays in `teoria.scale.scales` (e.g. a scale that is aeolian would also be minor), only the first match will set the `name` field. Again, you'll need to decide whether that is acceptable. 

Example:

``` javascript
teoria.scale('c', 'minor').name //returns "minor"
teoria.scale('c', 'aeolian').name //returns "aeolian"
teoria.scale('c', ['M2', 'm3', 'P4', 'P5', 'm6', 'm7']).name //always returns "minor"
```
## TeoriaNote#atDistance(semitoneDistance)

It was becoming annoying repeatedly doing `teoria.note.fromKey(note.key() + n)` whenever I wanted to get the note `n` semitones from `note`, so I added the `atDistance` convenience method to `TeoriaNote`.

Example:

``` javascript
teoria.note('c4').atDistance(2) //returns d4
teoria.note('c4').atDistance(-4) //returns g#3
```
