### PR TITLE
Implement TeoriaNote#scaleDegree method

### DIFF
--- a/teoria.js
+++ b/teoria.js
@@ -516,6 +516,24 @@ var scope = (typeof exports === 'object') ? exports : window;
     },
 
     /**
+     * Returns the degree of this note in a given scale
+     * If the scale doesn't contain this note, the scale degree
+     * will be returned as 0 allowing for expressions such as:
+     * if(teoria.note('a').scaleDegree(teoria.scale('a', 'major'))) {
+     *   ...
+     * }
+     *
+     * as 0 evaluates to false in boolean context
+     **/
+    scaleDegree: function(scale) {
+      var interval = scale.tonic.interval(this);
+      interval = (interval.direction === 'down' ||
+                  interval.simpleInterval === 8) ? interval.invert() : interval;
+
+      return scale.scale.indexOf(interval.simple()) + 1;
+    },
+
+    /**
      * Returns the name of the note, with an optional display of octave number
      */
     toString: function(dontShow) {
@@ -852,7 +870,7 @@ var scope = (typeof exports === 'object') ? exports : window;
     }
 
     this.name = scaleName;
-    this.notes = [tonic];
+    this.notes = [];
     this.tonic = tonic;
     this.scale = scale;
 
@@ -975,9 +993,7 @@ var scope = (typeof exports === 'object') ? exports : window;
     invert: function() {
       var intervalNumber = this.simpleInterval;
 
-      if (intervalNumber !== 8 && intervalNumber !== 1) {
-        intervalNumber = 9 - intervalNumber;
-      }
+      intervalNumber = 9 - intervalNumber;
 
       return new TeoriaInterval(intervalNumber,
                                 kQualityInversion[this.quality]);
@@ -1200,28 +1216,27 @@ var scope = (typeof exports === 'object') ? exports : window;
   /**
    * A list of scales, used internally by the TeoriaScale object.
    * Scales are written in absolute interval format.
-   * Notice that the root note (tonic) is not listed.
    */
   teoria.scale.scales = {
     // Modal Scales
-    major: ['M2', 'M3', 'P4', 'P5', 'M6', 'M7'],
-    ionian: ['M2', 'M3', 'P4', 'P5', 'M6', 'M7'],
-    dorian: ['M2', 'm3', 'P4', 'P5', 'M6', 'm7'],
-    phrygian: ['m2', 'm3', 'P4', 'P5', 'm6', 'm7'],
-    lydian: ['M2', 'M3', 'A4', 'P5', 'M6', 'M7'],
-    mixolydian: ['M2', 'M3', 'P4', 'P5', 'M6', 'm7'],
-    minor: ['M2', 'm3', 'P4', 'P5', 'm6', 'm7'],
-    aeolian: ['M2', 'm3', 'P4', 'P5', 'm6', 'm7'],
-    locrian: ['m2', 'm3', 'P4', 'd5', 'm6', 'm7'],
+    major: ['P1', 'M2', 'M3', 'P4', 'P5', 'M6', 'M7'],
+    ionian: ['P1', 'M2', 'M3', 'P4', 'P5', 'M6', 'M7'],
+    dorian: ['P1', 'M2', 'm3', 'P4', 'P5', 'M6', 'm7'],
+    phrygian: ['P1', 'm2', 'm3', 'P4', 'P5', 'm6', 'm7'],
+    lydian: ['P1', 'M2', 'M3', 'A4', 'P5', 'M6', 'M7'],
+    mixolydian: ['P1', 'M2', 'M3', 'P4', 'P5', 'M6', 'm7'],
+    minor: ['P1', 'M2', 'm3', 'P4', 'P5', 'm6', 'm7'],
+    aeolian: ['P1', 'M2', 'm3', 'P4', 'P5', 'm6', 'm7'],
+    locrian: ['P1', 'm2', 'm3', 'P4', 'd5', 'm6', 'm7'],
 
     // Pentatonic
-    majorpentatonic: ['M2', 'M3', 'P5', 'M6'],
-    minorpentatonic: ['m3', 'P4', 'P5', 'm7'],
+    majorpentatonic: ['P1', 'M2', 'M3', 'P5', 'M6'],
+    minorpentatonic: ['P1', 'm3', 'P4', 'P5', 'm7'],
 
     // Chromatic
-    chromatic: ['m2', 'M2', 'm3', 'M3', 'P4', 'A4',
+    chromatic: ['P1', 'm2', 'M2', 'm3', 'M3', 'P4', 'A4',
                 'P5', 'm6', 'M6', 'm7', 'M7'],
-    harmonicchromatic: ['m2', 'M2', 'm3', 'M3', 'P4', 'A4',
+    harmonicchromatic: ['P1', 'm2', 'M2', 'm3', 'M3', 'P4', 'A4',
                 'P5', 'm6', 'M6', 'm7', 'M7']
   };
 

--- a/test/teoria.js
+++ b/test/teoria.js
@@ -443,6 +443,38 @@ var suite = vows.describe('Teoria Framework').addBatch({
       }
     },
 
+    'Scale Degrees': {
+      'Eb is scale degree 1 (tonic) in an Eb minor scale': function() {
+        var note = teoria.note('eb');
+        assert.equal(note.scaleDegree(teoria.scale('eb', 'major')), 1);
+      },
+
+      'E is scale degree 3 in a C# dorian': function() {
+        var note = teoria.note('e');
+        assert.equal(note.scaleDegree(teoria.scale('c#', 'dorian')), 3);
+      },
+
+      'C is scale degree 0 in a D major scale (not in scale)': function() {
+        var note = teoria.note('c');
+        assert.equal(note.scaleDegree(teoria.scale('d', 'major')), 0);
+      },
+
+      'Bb is scale degree 7 in a C minor': function() {
+        var note = teoria.note('bb');
+        assert.equal(note.scaleDegree(teoria.scale('c', 'minor')), 7);
+      },
+      
+      'Db is scale degree 4 in an Ab major scale': function() {
+        var note = teoria.note('db');
+        assert.equal(note.scaleDegree(teoria.scale('ab', 'major')), 4);
+      },
+
+      'A# is scale degree 0 in a G minor scale': function() {
+        var note = teoria.note('a#');
+        assert.equal(note.scaleDegree(teoria.scale('g', 'minor')), 0);
+      }
+    },
+
     'Compound Intervals': {
       'A major seventeenth is a compound interval': function() {
         assert.equal(teoria.interval('M17').isCompound(), true);


### PR DESCRIPTION
In response to the feature request in Issue #12 I came up with this method which is a mixture of the proposed `TeoriaNote#isScaleDegree` and `TeoriaNote#getScaleDegree`.

The new method `TeoriaNote#scaleDegree(scale)` returns the scale degree of a note, given a scale. Its syntax is much like the other methods of the framework:

``` javascript
var scale = teoria.scale('eb4', 'major');
teoria.note('eb4').scaleDegree(scale); // Returns 1 as it is the proper degree number
teoria.note('f2').scaleDegree(scale); // Returns 2
teoria.note('g3').scaleDegree(scale); // Returns 3
teoria.note('g4').scaleDegree(scale); // Returns also 3
teoria.note('g5').scaleDegree(scale); // Returns also 3
teoria.note('a4').scaleDegree(scale); // Returns 0 as it is not listed in the scale
teoria.note('b5').scaleDegree(scale); // Returns 0
teoria.note('d#4').scaleDegree(scale); // Returns 0 as well.
```

The "clever" thing here is that notes that aren't in the scale will return 0, and in JavaScript 0 evaluates to `false` in a Boolean context, so that this method can be used just as a `isScaleDegree` method would be, e.g.:

``` javascript
if (note.scaleDegree(randomScale)) {
  // ...
}

// or for the more pedantic of us
if (!!note.scaleDegree(randomScale)) {
  // ...
}

// or for the *really* pedantic of us
if (note.scaleDegree(randomScale) !== 0) {
  // ...
}

```

I'm not quite sure however if this should be exploited, and I'd like a little feedback on this, and to hear if there's any objections against this.

@LukeHorvat, @GregJ - You guys have been active lately, any thoughts about this?
