### PR TITLE
Support for UglifyJS2

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -33,17 +33,17 @@ function log(text, type, acolor, nolabel) {
   if (!settings.silent) {
     if (!nolabel) {
       text = ' [' + type.toUpperCase() + '] ' + text;
-   } else {
+    } else {
       text = ' ' + text;
-   }
+    }
 
     if (settings.colors && colors) {
       acolor = logcolors[acolor || type] || 'grey';
       console[type](text[acolor]);
-   } else {
+    } else {
       console[type](text);
-   }
- }
+    }
+  }
 }
 
 // Constants
@@ -73,15 +73,15 @@ function doBuild() {
   params.forEach(function(el) {
     if (el in settings) {
       settings[el] = !settings[el];
-   } else {
+    } else {
       log('Ignoring invalid settings: ' + el, 'warn');
-   }
- });
+    }
+  });
 
   if (!existsSync(kDistDir)) {
     log('Creating ' + kDistDir + ' directory');
     fs.mkdirSync(kDistDir, 0x01FF); // With 0777 mode
- }
+  }
 
   // Change to /src dir
   process.chdir(kSrcDir);
@@ -92,10 +92,10 @@ function doBuild() {
       var ugly, ast, ratio, compressed;
       try {
         ugly = require('uglify-js');
-     } catch (e) {
+      } catch (e) {
         return log('uglify-js module doesn\'t appear to be installed. Use:' +
           '`npm install uglify-js`', 'error');
-     }
+      }
 
       log('Minifying');
 
@@ -108,9 +108,9 @@ function doBuild() {
       log('Saved ' + ratio + '% of the original size');
       concatenation = compressed;
       filename = kDistMinFilename;
-   } else {
+    } else {
       filename = kDistFilename;
-   }
+    }
 
     // Write to file and close!
     log('Writing to output file \'' + filename + '\'');
@@ -118,24 +118,24 @@ function doBuild() {
     log('Concatenation completed - Goodbye!');
 
     complete();
- });
+  });
 
   mingler.on('error', function(error) {
     log(error, 'error');
     process.exit(1);
- });
+  });
 
   mingler.on('warning', function(warning) {
     log(warning, 'warn');
- });
+  });
 
   mingler.on('concatenate', function(feedback) {
     log("Concatenating: " + feedback.filename, 'info', 'grey');
- });
+  });
 
   mingler.mingle(kMainFile, function() {
     process.chdir('../');
- });
+  });
 }
 
 // Concatenates the files
@@ -152,7 +152,7 @@ desc('Builds the project and unit tests it');
 task('test', ['build'], function() {
   jake.exec('node test/teoria.js', function() {
     complete();
- }, {printStdout: true});
+  }, {printStdout: true});
 }, {async: true});
 
 // Lints the files according to .jshintrc
@@ -161,12 +161,12 @@ task('lint', function() {
   var jshint, config, errors, errorfilecount, content;
   try {
     jshint = require('jshint');
- } catch (e) {
+  } catch (e) {
     console.log(e);
     log('jshint doesn\'t appear to be installed. Do a `npm install -g jshint`',
       'error');
     return false;
- }
+  }
 
   // Load configuration
   config = fs.readFileSync('./.jshintrc', 'utf8');
@@ -177,9 +177,9 @@ task('lint', function() {
   kFileList.forEach(function(file) {
     try {
       content = fs.readFileSync(file, 'utf8');
-   } catch (e) {
+    } catch (e) {
       log('Unable to open file ' + file, 'error');
-   }
+    }
 
     content = content.replace(/^\uFEFF/, ''); // Remove Unicode BOM
     if (!jshint.JSHINT(content, config)) {
@@ -187,10 +187,10 @@ task('lint', function() {
       jshint.JSHINT.errors.forEach(function(error) {
         if (error) {
           errors.push({file: file, error: error});
-       }
+        }
      });
-   }
- });
+    }
+  });
 
   log(kFileList.length.toString(10) + ' files linted, ' +
       (kFileList.length - errorfilecount) +
@@ -201,13 +201,12 @@ task('lint', function() {
     log(error.file + ': line ' + error.error.line +
         ', col ' + error.error.character + ', ' + error.error.reason,
         'error', 'grey', true);
- });
+  });
 
   // Show lint status
   if (errors.length === 0) {
     log('Lint passed', 'info');
- } else {
+  } else {
     log('Lint failed!', 'error');
- }
+  }
 });
-


### PR DESCRIPTION
A new "npm install ugly-js" installs UglifyJS2 instead of Uglify...this code works with UglifyJS2.

It might be beneficial to revise these changes to support both versions?
