### PR TITLE
New Feature: TeoriaProgression

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -4,6 +4,7 @@
     "TeoriaInterval",
     "TeoriaChord",
     "TeoriaScale",
+    "TeoriaProgression",
     "teoria",
 
     "kDurations",

--- a/src/core.js
+++ b/src/core.js
@@ -374,16 +374,26 @@
 
   teoria.scale.scales = {};
 
+  // teoria.progression namespace
+  teoria.progression = function(scale, progression) {
+    if(scale instanceof TeoriaScale && progression instanceof Array) {
+      return new TeoriaProgression(scale, progression);
+    }
+    throw new Error('Invalid parameters');
+  };
+
   //=include note.js
   //=include interval.js
   //=include chord.js
   //=include scale.js
   //=include #scales#
+  //=include progression.js
 
   teoria.TeoriaNote = TeoriaNote;
   teoria.TeoriaChord = TeoriaChord;
   teoria.TeoriaScale = TeoriaScale;
   teoria.TeoriaInterval = TeoriaInterval;
+  teoria.TeoriaProgression = TeoriaProgression;
 
   if (typeof exports !== 'undefined') {
     if (typeof module !== 'undefined' && module.exports)

--- a/src/progression.js
+++ b/src/progression.js
@@ -10,18 +10,19 @@ function TeoriaProgression(scale, progression) {
   this.scale = scale;
   this.progression = progression;
   this.chords = progression.map(function(chordIndex) {
-    var chord = teoria.chord(scale.tonic),
+    var chord = teoria.chord(scale.notes()[chordIndex - 1]),
         chordLength = 3,
         voicing = [],
-        voiceIndex;
+        noteIndex;
 
     for(var i = 0; i < chordLength; i++) {
-      voiceIndex = (i * 2) + (chordIndex - 1);
-      voiceIndex = voiceIndex % scale.scale.length;
-      voicing.push(scale.scale[voiceIndex]);
+      noteIndex = (chordIndex - 1) + i * 2;
+      noteIndex = noteIndex % scale.notes().length;
+      voicing.push(teoria.interval(chord.root, scale.notes()[noteIndex]).toString());
     }
 
-    return chord.voicing(voicing);
+    chord.voicing(voicing);
+    return chord;
   });
 }
 
@@ -32,5 +33,8 @@ TeoriaProgression.prototype = {
         return note.toString();
       });
     });
+  },
+  getChord: function(i) {
+    return this.chords[i];
   }
 };

--- a/src/progression.js
+++ b/src/progression.js
@@ -1,0 +1,35 @@
+function TeoriaProgression(scale, progression) {
+  if (!(scale instanceof TeoriaScale)) {
+    throw new Error('Invalid Scale');
+  }
+
+  if (!(progression instanceof Array)) {
+    throw new Error('Invalid Progression');
+  }
+
+  this.scale = scale;
+  this.chords = progression.map(function(chordIndex) {
+    var chord = teoria.chord(scale.tonic),
+        chordLength = 3,
+        voicing = [],
+        voiceIndex;
+
+    for(var i = 0; i < chordLength; i++) {
+      voiceIndex = (i * 2) + (chordIndex - 1);
+      voiceIndex = voiceIndex % scale.scale.length;
+      voicing.push(scale.scale[voiceIndex]);
+    }
+
+    return chord.voicing(voicing);
+  });
+}
+
+TeoriaProgression.prototype = {
+  simple: function() {
+    return this.chords.map(function(chord) {
+      return chord.notes().map(function(note){
+        return note.toString();
+      });
+    });
+  }
+};

--- a/src/progression.js
+++ b/src/progression.js
@@ -10,20 +10,41 @@ function TeoriaProgression(scale, progression) {
   this.scale = scale;
   this.progression = progression;
   this.chords = progression.map(function(chordIndex) {
-    var chord = teoria.chord(scale.notes()[chordIndex - 1]),
+    var root = scale.notes()[chordIndex - 1],
         chordLength = 3,
         voicing = [],
-        noteIndex;
+        noteIndex,
+        interval;
 
-    for(var i = 0; i < chordLength; i++) {
-      noteIndex = (chordIndex - 1) + i * 2;
+    for(var i = 1; i < chordLength; i++) {
+      noteIndex = (chordIndex - 1) + (i * 2);
       noteIndex = noteIndex % scale.notes().length;
-      voicing.push(teoria.interval(chord.root, scale.notes()[noteIndex]).toString());
+      interval = teoria.interval(root, scale.notes()[noteIndex]);
+      interval = interval.direction() === 'down' ? interval.invert() : interval;
+      voicing.push(interval.toString());
     }
 
-    chord.voicing(voicing);
-    return chord;
+    return teoria.chord(root, findMatchingSymbol(voicing));
   });
+
+  function findMatchingSymbol(intervals) {
+    for(var kSymbol in kSymbols) {
+      var symbolIntervals = kSymbols[kSymbol];
+      if(arraysIdentical(intervals, symbolIntervals)) {
+        return kSymbol;
+      }
+    }
+    return '';
+  }
+
+  function arraysIdentical(a, b) {
+    var i = a.length;
+    if (i !== b.length) return false;
+    while (i--) {
+      if (a[i] !== b[i]) return false;
+    }
+    return true;
+  }
 }
 
 TeoriaProgression.prototype = {

--- a/src/progression.js
+++ b/src/progression.js
@@ -8,6 +8,7 @@ function TeoriaProgression(scale, progression) {
   }
 
   this.scale = scale;
+  this.progression = progression;
   this.chords = progression.map(function(chordIndex) {
     var chord = teoria.chord(scale.tonic),
         chordLength = 3,

--- a/test/progressions.js
+++ b/test/progressions.js
@@ -27,5 +27,25 @@ vows.describe('Progressions').addBatch({
 
             assert.deepEqual(twoFiveOne.simple(), [['eb3','gb3','bb3'],['ab3','c4','eb3'],['db3','f3','ab3']]);
         }
+    },
+    'Creates chords with correct root': {
+        'First chord': function() {
+            var scale = teoria.scale('c4', 'major'),
+                twoFiveOne = teoria.progression(scale, [2,5,1]);
+
+            assert.equal(twoFiveOne.getChord(0).root.toString(), 'd4');
+        },
+        'Second chord': function() {
+            var scale = teoria.scale('c4', 'major'),
+                twoFiveOne = teoria.progression(scale, [2,5,1]);
+
+            assert.equal(twoFiveOne.getChord(1).root.toString(), 'g4');
+        },
+        'Third chord': function() {
+            var scale = teoria.scale('c4', 'major'),
+                twoFiveOne = teoria.progression(scale, [2,5,1]);
+
+            assert.equal(twoFiveOne.getChord(2).root.toString(), 'c4');
+        }
     }
 }).export(module);

--- a/test/progressions.js
+++ b/test/progressions.js
@@ -8,19 +8,19 @@ vows.describe('Progressions').addBatch({
       var scale = teoria.scale('c3', 'ionian'),
           twoFiveOne = teoria.progression(scale, [2, 5, 1]);
 
-      assert.deepEqual(twoFiveOne.simple(), [['d3', 'f3', 'a3'], ['g3', 'b3', 'd3'], ['c3', 'e3', 'g3']]);
+      assert.deepEqual(twoFiveOne.simple(), [['d3', 'f3', 'a3'], ['g3', 'b3', 'd4'], ['c3', 'e3', 'g3']]);
     },
     'A Minor': function() {
       var scale = teoria.scale('a3', 'aeolian'),
           twoFiveOne = teoria.progression(scale, [2, 5, 1]);
 
-      assert.deepEqual(twoFiveOne.simple(), [['b3', 'd4', 'f4'], ['e4', 'g4', 'b3'], ['a3', 'c4', 'e4']]);
+      assert.deepEqual(twoFiveOne.simple(), [['b3', 'd4', 'f4'], ['e4', 'g4', 'b4'], ['a3', 'c4', 'e4']]);
     },
     'Db Major': function() {
       var scale = teoria.scale('db3', 'ionian'),
           twoFiveOne = teoria.progression(scale, [2, 5, 1]);
 
-      assert.deepEqual(twoFiveOne.simple(), [['eb3', 'gb3', 'bb3'], ['ab3', 'c4', 'eb3'], ['db3', 'f3', 'ab3']]);
+      assert.deepEqual(twoFiveOne.simple(), [['eb3', 'gb3', 'bb3'], ['ab3', 'c4', 'eb4'], ['db3', 'f3', 'ab3']]);
     }
   },
   'Creates chords with correct root': {
@@ -41,6 +41,26 @@ vows.describe('Progressions').addBatch({
           twoFiveOne = teoria.progression(scale, [2, 5, 1]);
 
       assert.equal(twoFiveOne.getChord(2).root.toString(), 'c4');
+    }
+  },
+  'Creates chords with correct symbol': {
+    'First chord': function() {
+      var scale = teoria.scale('c4', 'major'),
+        twoFiveOne = teoria.progression(scale, [2, 5, 1]);
+
+      assert.equal(twoFiveOne.getChord(0).toString(), 'Dmin');
+    },
+    'Second chord': function() {
+      var scale = teoria.scale('c4', 'major'),
+        twoFiveOne = teoria.progression(scale, [2, 5, 1]);
+
+      assert.equal(twoFiveOne.getChord(1).toString(), 'GM');
+    },
+    'Third chord': function() {
+      var scale = teoria.scale('c4', 'major'),
+        twoFiveOne = teoria.progression(scale, [2, 5, 1]);
+
+      assert.equal(twoFiveOne.getChord(2).toString(), 'CM');
     }
   }
 }).export(module);

--- a/test/progressions.js
+++ b/test/progressions.js
@@ -1,0 +1,31 @@
+var vows = require('vows'),
+    assert = require('assert'),
+    teoria = require('../dist/teoria.js');
+
+// Utility function
+function simpleArray(chord) {
+    return chord.notes().map(function(n) { return n.toString(true); });
+}
+
+vows.describe('Progressions').addBatch({
+    'Progression parser': {
+        'C Major': function() {
+            var scale = teoria.scale('c3', 'ionian'),
+                twoFiveOne = teoria.progression(scale, [2,5,1]);
+
+            assert.deepEqual(twoFiveOne.simple(), [['d3','f3','a3'],['g3','b3','d3'],['c3','e3','g3']]);
+        },
+        'A Minor': function() {
+            var scale = teoria.scale('a3', 'aeolian'),
+                twoFiveOne = teoria.progression(scale, [2,5,1]);
+
+            assert.deepEqual(twoFiveOne.simple(), [['b3','d4','f4'],['e4','g4','b3'],['a3','c4','e4']]);
+        },
+        'Db Major': function() {
+            var scale = teoria.scale('db3', 'ionian'),
+                twoFiveOne = teoria.progression(scale, [2,5,1]);
+
+            assert.deepEqual(twoFiveOne.simple(), [['eb3','gb3','bb3'],['ab3','c4','eb3'],['db3','f3','ab3']]);
+        }
+    }
+}).export(module);

--- a/test/progressions.js
+++ b/test/progressions.js
@@ -2,50 +2,45 @@ var vows = require('vows'),
     assert = require('assert'),
     teoria = require('../dist/teoria.js');
 
-// Utility function
-function simpleArray(chord) {
-    return chord.notes().map(function(n) { return n.toString(true); });
-}
-
 vows.describe('Progressions').addBatch({
-    'Progression parser': {
-        'C Major': function() {
-            var scale = teoria.scale('c3', 'ionian'),
-                twoFiveOne = teoria.progression(scale, [2,5,1]);
+  'Progression parser': {
+    'C Major': function() {
+      var scale = teoria.scale('c3', 'ionian'),
+          twoFiveOne = teoria.progression(scale, [2, 5, 1]);
 
-            assert.deepEqual(twoFiveOne.simple(), [['d3','f3','a3'],['g3','b3','d3'],['c3','e3','g3']]);
-        },
-        'A Minor': function() {
-            var scale = teoria.scale('a3', 'aeolian'),
-                twoFiveOne = teoria.progression(scale, [2,5,1]);
-
-            assert.deepEqual(twoFiveOne.simple(), [['b3','d4','f4'],['e4','g4','b3'],['a3','c4','e4']]);
-        },
-        'Db Major': function() {
-            var scale = teoria.scale('db3', 'ionian'),
-                twoFiveOne = teoria.progression(scale, [2,5,1]);
-
-            assert.deepEqual(twoFiveOne.simple(), [['eb3','gb3','bb3'],['ab3','c4','eb3'],['db3','f3','ab3']]);
-        }
+      assert.deepEqual(twoFiveOne.simple(), [['d3', 'f3', 'a3'], ['g3', 'b3', 'd3'], ['c3', 'e3', 'g3']]);
     },
-    'Creates chords with correct root': {
-        'First chord': function() {
-            var scale = teoria.scale('c4', 'major'),
-                twoFiveOne = teoria.progression(scale, [2,5,1]);
+    'A Minor': function() {
+      var scale = teoria.scale('a3', 'aeolian'),
+          twoFiveOne = teoria.progression(scale, [2, 5, 1]);
 
-            assert.equal(twoFiveOne.getChord(0).root.toString(), 'd4');
-        },
-        'Second chord': function() {
-            var scale = teoria.scale('c4', 'major'),
-                twoFiveOne = teoria.progression(scale, [2,5,1]);
+      assert.deepEqual(twoFiveOne.simple(), [['b3', 'd4', 'f4'], ['e4', 'g4', 'b3'], ['a3', 'c4', 'e4']]);
+    },
+    'Db Major': function() {
+      var scale = teoria.scale('db3', 'ionian'),
+          twoFiveOne = teoria.progression(scale, [2, 5, 1]);
 
-            assert.equal(twoFiveOne.getChord(1).root.toString(), 'g4');
-        },
-        'Third chord': function() {
-            var scale = teoria.scale('c4', 'major'),
-                twoFiveOne = teoria.progression(scale, [2,5,1]);
-
-            assert.equal(twoFiveOne.getChord(2).root.toString(), 'c4');
-        }
+      assert.deepEqual(twoFiveOne.simple(), [['eb3', 'gb3', 'bb3'], ['ab3', 'c4', 'eb3'], ['db3', 'f3', 'ab3']]);
     }
+  },
+  'Creates chords with correct root': {
+    'First chord': function() {
+      var scale = teoria.scale('c4', 'major'),
+          twoFiveOne = teoria.progression(scale, [2, 5, 1]);
+
+      assert.equal(twoFiveOne.getChord(0).root.toString(), 'd4');
+    },
+    'Second chord': function() {
+      var scale = teoria.scale('c4', 'major'),
+          twoFiveOne = teoria.progression(scale, [2, 5, 1]);
+
+      assert.equal(twoFiveOne.getChord(1).root.toString(), 'g4');
+    },
+    'Third chord': function() {
+      var scale = teoria.scale('c4', 'major'),
+          twoFiveOne = teoria.progression(scale, [2, 5, 1]);
+
+      assert.equal(twoFiveOne.getChord(2).root.toString(), 'c4');
+    }
+  }
 }).export(module);


### PR DESCRIPTION
TeoriaProgression
-------------------------
_A new feature for constructing and managing diatonic chord progressions._

I needed this for a project, so I added it!

First PR, so apologies if this is no good. Let me know if it's not worthy... or if you don't think this belongs in Teoria.

```
var cMajScale = teoria.scale('c', 'major');
var twoFiveOne = teoria.progression(cMajScale, [2, 5, 1]);

twoFiveOne.getChord(0).toString(); // 'Dmin'
twoFiveOne.getChord(1).toString(); // 'GM'
twoFiveOne.getChord(2).toString(); // 'CM'

twoFiveOne.simple(); // [['d3','f3','a3'], ['g3','b3','d4'], ['c3','e3','g3']]
```

I've only implemented `TeoriaProgression.simple()` & `TeoriaProgression.getChord(n)` so far.

Because of the way the chords are built, this will only work for the standard modes. God knows what kind of exotic harmony would be generated from the pentatonics or blues scales. This needs sorting... I wanted to get your opinion before I continue though.

It'd be cool to add...
- support for 7th chords and more... diatonic triads are boring.
- support for Roman numerals in the constructor - TeoriaProgression(scale, ['II', 'IV', 'I'])
- progression.transpose()
- progression.substitute(i, chord)
- blurb in the Readme
- a little web audio demo

Feedback welcome!