### PR TITLE
Added extra scales to default build options

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -63,7 +63,13 @@ var includeScales = {
 
   'majorpentatonic': true,
   'minorpentatonic': true,
-  'chromatic': true
+  'chromatic': true,
+
+  'blues': true,
+  'doubleharmonic': true,
+  'flamenco': true,
+  'harmonicminor': true,
+  'melodicminor': true
 };
 
 // Default task - lint and build

--- a/README.md
+++ b/README.md
@@ -391,6 +391,11 @@ absolute intervals that defines the scale. The scales supported by default are:
  - minorpentatonic
  - chromatic
  - harmonicchromatic (Alias for chromatic)
+ - blues
+ - doubleharmonic
+ - flamenco
+ - harmonicminor
+ - melodicminor
 
 ### teoria.scale(tonic, scale)
  - Sugar function for constructing a new `TeoriaScale` object


### PR DESCRIPTION
blues, doubleharmonic, flamenco, harmonicminor and melodicminor

Although there already exists more scales but default build options does not include all the scales.
I found that when I tried using harmonic minor.

If there isn't any special reason for that, I think it would be much more convenient to contain all other remaining scales as default.