### PR TITLE
Add signature method for a scale. Closes #89

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,9 @@ The chroma number is ranging from pitch class C which is 0 to 11 which is B
 #### Note#interval(interval)
  - A sugar function for calling teoria.interval(note, interval);
 
-Returns a new note based on the passed interval.
 
 Look at the documentation for `teoria.interval`
+
 
 #### Note#transpose(interval)
  - Like the `#interval` method, but changes `this` note, instead of returning a new

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ The chroma number is ranging from pitch class C which is 0 to 11 which is B
 #### Note#interval(interval)
  - A sugar function for calling teoria.interval(note, interval);
 
+Returns a new note based on the passed interval.
+
 Look at the documentation for `teoria.interval`
 
 #### Note#transpose(interval)
@@ -414,6 +416,9 @@ scale step. E.g. 'first', 'second', 'fourth', 'seventh'.
 *index* Same as `Scale#get`
 
 *showOctaves* - A boolean meaning the same as `showOctaves` in `Note#solfege`
+
+#### Scale#signature()
+ - Returns the sequence of notes representing the key signature of a scale
 
 
 ## teoria.interval(from, to)

--- a/lib/scale.js
+++ b/lib/scale.js
@@ -112,8 +112,6 @@ Scale.prototype = {
    * Flats signature is got by traversing by P4 intervals to the left in the same manner, which is equal to reversed sharps.
    */
   signature: function() {
-    var offset = this.tonic.coord[1];
-
     var sequence = this.notes().sort(function (a, b) {
       var aCoord = a.coord[1] < 0 ? a.coord[1] + 12 : a.coord[1];
       var bCoord = b.coord[1] < 0 ? b.coord[1] + 12 : b.coord[1];

--- a/lib/scale.js
+++ b/lib/scale.js
@@ -118,10 +118,11 @@ Scale.prototype = {
       return aCoord - bCoord;
     });
 
-    //if at least one flat - return flats signature
-    if (sequence.some(function (note) {
+    var hasFlat = sequence.some(function (note) {
       return note.accidentalValue() < 0;
-    })) {
+    });
+
+    if (hasFlat) {
       sequence = sequence.reverse();
     }
 

--- a/lib/scale.js
+++ b/lib/scale.js
@@ -122,15 +122,12 @@ Scale.prototype = {
     if (sequence.some(function (note) {
       return note.accidentalValue() < 0;
     })) {
-      return sequence.reverse().filter(function (note) {
-        return note.accidentalValue() !== 0;
-      });
+      sequence = sequence.reverse();
     }
-    else {
-      return sequence.filter(function (note) {
-        return note.accidentalValue() !== 0;
-      });
-    }
+
+    return sequence.filter(function (note) {
+      return note.accidentalValue() !== 0;
+    });
   }
 };
 

--- a/lib/scale.js
+++ b/lib/scale.js
@@ -102,6 +102,37 @@ Scale.prototype = {
     this.tonic = scale.tonic;
 
     return this;
+  },
+
+  /**
+   * Get the sequence of notes representing key signature of a scale, in proper order.
+   * There are two possible signatures for any scale: flats and sharps.
+   * Sharps signature is got by traversing notes by P5 intervals to the right
+   * till all the notes of the scale are covered.
+   * Flats signature is got by traversing by P4 intervals to the left in the same manner, which is equal to reversed sharps.
+   */
+  signature: function() {
+    var offset = this.tonic.coord[1];
+
+    var sequence = this.notes().sort(function (a, b) {
+      var aCoord = a.coord[1] < 0 ? a.coord[1] + 12 : a.coord[1];
+      var bCoord = b.coord[1] < 0 ? b.coord[1] + 12 : b.coord[1];
+      return aCoord - bCoord;
+    });
+
+    //if at least one flat - return flats signature
+    if (sequence.some(function (note) {
+      return note.accidentalValue() < 0;
+    })) {
+      return sequence.reverse().filter(function (note) {
+        return note.accidentalValue() !== 0;
+      });
+    }
+    else {
+      return sequence.filter(function (note) {
+        return note.accidentalValue() !== 0;
+      });
+    }
   }
 };
 

--- a/test/scales.js
+++ b/test/scales.js
@@ -57,6 +57,18 @@ vows.describe('Scales').addBatch({
       assert.deepEqual(note.scale('chromatic').simple(),
           ["ab", "bbb", "bb", "cb", "c", "db",
            "d", "eb", "fb", "f", "gb", "g"]);
+    },
+
+    'Signature': function(note) {
+      function name (note) {return note.name() + note.accidental() }
+
+      assert.equal(teoria.note('f#').scale('major').signature().map(name).toString(), 'f#,c#,g#,d#,a#,e#');
+      assert.equal(teoria.note('db').scale('major').signature().map(name).toString(), 'bb,eb,ab,db,gb');
+
+      assert.equal(teoria.note('c').scale('major').signature().map(name).toString(), '');
+      assert.equal(teoria.note('a').scale('minor').signature().map(name).toString(), '');
+      assert.equal(teoria.note('d').scale('major').signature().map(name).toString(), 'f#,c#');
+      assert.equal(teoria.note('b').scale('minor').signature().map(name).toString(), 'f#,c#');
     }
   }
 }).export(module);


### PR DESCRIPTION
Hi, @matthewconstantine!
I’ve implemented, as it seems to me so far, the most logical method of getting key signatures for any scale with any tonic, based on note coordinates. It is quite late here and there might be some mistake, but tests of basic major/minor scales are passed. So please take a look, it should be nice ).
It closes #89.
