### PR TITLE
Expose the list of known scales as part of the Scale class

### DIFF
--- a/lib/scale.js
+++ b/lib/scale.js
@@ -17,7 +17,7 @@ var scales = {
   mixolydian: ['P1', 'M2', 'M3', 'P4', 'P5', 'M6', 'm7'],
   phrygian: ['P1', 'm2', 'm3', 'P4', 'P5', 'm6', 'm7'],
   wholetone: ['P1', 'M2', 'M3', 'A4', 'A5', 'A6']
-}
+};
 
 // synonyms
 scales.harmonicchromatic = scales.chromatic;
@@ -105,5 +105,6 @@ Scale.prototype = {
     return this;
   }
 };
+Scale.KNOWN_SCALES = Object.keys(scales);
 
 module.exports = Scale;


### PR DESCRIPTION
Proposal for #94. It would maybe be nice to provide "human names" for the scales, too, esp. for cases like "doubleharmonic", "majorpentatonic" and such, but having the scale ids that can be passed to the Scale constructor is a good step forward.

Ideas?