### PR TITLE
Doc fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,14 +380,14 @@ absolute intervals that defines the scale. The scales supported by default are:
 ### teoria.scale(tonic, scale)
  - Sugar function for constructing a new `Scale` object
 
-#### Scale.notes()
- - Returns an array of `Note`s which is the scale's notes
-
 #### Scale.name
  - The name of the scale (if available). Type `string` or `undefined`
 
 #### Scale.tonic
  - The `Note` which is the scale's tonic
+
+#### Scale#notes()
+ - Returns an array of `Note`s which is the scale's notes
 
 #### Scale#simple()
  - Returns an `Array` of only the notes' names, not the full `Note` objects.

--- a/lib/scale.js
+++ b/lib/scale.js
@@ -17,7 +17,7 @@ var scales = {
   mixolydian: ['P1', 'M2', 'M3', 'P4', 'P5', 'M6', 'm7'],
   phrygian: ['P1', 'm2', 'm3', 'P4', 'P5', 'm6', 'm7'],
   wholetone: ['P1', 'M2', 'M3', 'A4', 'A5', 'A6']
-}
+};
 
 // synonyms
 scales.harmonicchromatic = scales.chromatic;
@@ -105,5 +105,6 @@ Scale.prototype = {
     return this;
   }
 };
+Scale.KNOWN_SCALES = Object.keys(scales);
 
 module.exports = Scale;


### PR DESCRIPTION
If I'm not mistaken, the "notes" method in Scale should have been documented as Scale#notes(). This tiny pull request fixes the documentation in the README file.