### PR TITLE
Typo: "linaer" changed to "linear"

### DIFF
--- a/lib/knowledge.js
+++ b/lib/knowledge.js
@@ -30,7 +30,7 @@ module.exports = {
                       'eleventh', 'twelfth', 'thirteenth', 'fourteenth',
                       'fifteenth'],
 
-// linaer index to fifth = (2 * index + 1) % 7
+// linear index to fifth = (2 * index + 1) % 7
   fifths: ['f', 'c', 'g', 'd', 'a', 'e', 'b'],
   accidentals: ['bb', 'b', '', '#', 'x'],
 


### PR DESCRIPTION
Hi guys, I just found typo in comment: "linaer" changed to "linear".