### PR TITLE
Make it possible to create interval from semitones

### DIFF
--- a/lib/interval.js
+++ b/lib/interval.js
@@ -136,6 +136,14 @@ Interval.prototype = {
     return !this.equal(interval) && !this.greater(interval);
   },
 
+  fromSemitones: function(index) {
+    var coord = knowledge.intervalsSemitones[index];
+    if (!coord)
+      throw new Error('Invalid index');
+
+    return new Interval(coord);
+  },
+
   add: function(interval) {
     return new Interval(vector.add(this.coord, interval.coord));
   },

--- a/lib/knowledge.js
+++ b/lib/knowledge.js
@@ -22,6 +22,22 @@ module.exports = {
     octave: [1, 0]
   },
 
+  intervalsSemitones: {
+    0:  [0, 0],
+    1:  [3, -5],
+    2:  [-1, 2],
+    3:  [2, -3],
+    4:  [-2, 4],
+    5:  [1, -1],
+    6:  [-3, 6],
+    7:  [0, 1],
+    8:  [3, -4],
+    9:  [-1, 3],
+    10: [2, -2],
+    11: [-2, 5],
+    12: [1, 0]
+  },
+
   intervalFromFifth: ['second', 'sixth', 'third', 'seventh', 'fourth',
                          'unison', 'fifth'],
 

--- a/lib/note.js
+++ b/lib/note.js
@@ -90,6 +90,11 @@ Note.prototype = {
     return this;
   },
 
+  transposeNew: function(interval) {
+    var coord = vector.add(this.coord, interval.coord);
+    return new Note(coord);
+  },
+
   /**
    * Returns the Helmholtz notation form of the note (fx C,, d' F# g#'')
    */

--- a/teoria.js
+++ b/teoria.js
@@ -446,6 +446,14 @@ Interval.prototype = {
     return !this.equal(interval) && !this.greater(interval);
   },
 
+  fromSemitones: function(index) {
+    var coord = knowledge.intervalsSemitones[index];
+    if (!coord)
+      throw new Error('Invalid index');
+
+    return new Interval(coord);
+  },
+
   add: function(interval) {
     return new Interval(vector.add(this.coord, interval.coord));
   },
@@ -503,6 +511,22 @@ module.exports = {
     sixth: [3, -4],
     seventh: [2, -2],
     octave: [1, 0]
+  },
+
+  intervalsSemitones: {
+    0:  [0, 0],
+    1:  [3, -5],
+    2:  [-1, 2],
+    3:  [2, -3],
+    4:  [-2, 4],
+    5:  [1, -1],
+    6:  [-3, 6],
+    7:  [0, 1],
+    8:  [3, -4],
+    9:  [-1, 3],
+    10: [2, -2],
+    11: [-2, 5],
+    12: [1, 0]
   },
 
   intervalFromFifth: ['second', 'sixth', 'third', 'seventh', 'fourth',
@@ -735,6 +759,11 @@ Note.prototype = {
   transpose: function(interval) {
     this.coord = vector.add(this.coord, interval.coord);
     return this;
+  },
+
+  transposeNew: function(interval) {
+    var coord = vector.add(this.coord, interval.coord);
+    return new Note(coord);
   },
 
   /**


### PR DESCRIPTION
I was looking for a way to create an interval from number of semitones from a reference note, something similar with [music.js's Interval.fromSemitones()](https://github.com/gregjopa/music.js/blob/06e8f97d135cab10e85ac180ccea78454cdccd77/music.js#L242-L244).

It's a bit verbose (please let me know if there's a better way), but it works as expected:

```js
teoria.Interval().fromSemitones(0).name()  // => 'unison'
teoria.Interval().fromSemitones(1).name()  // => 'second'
```

I also added a helpful method to transpose a note without mutating it:

```js
c = teoria.note('c')
c.name()  // => 'c'
c.transposeNew(teoria.Interval().fromSemitones(1)).name() // => 'd'
c.name()  // => 'c' (no changes on original note)
```

With the original `Note.transpose()` method we change the note itself:

```js
c = teoria.note('c')
c.name()  // => 'c'
c.transpose(teoria.Interval().fromSemitones(1)).name() // => 'd'
c.name()  // => 'd' (note changed)
```
Please let me know if there's something I can improve on the PR. I'm actually using it on [this live coding language](http://github.com/automata/vivace) where it's handy to create notes from intervals defined by semitones.